### PR TITLE
Mobile menu toggle: swap icon and add red circular open-state styling

### DIFF
--- a/src/components/so-header.ts
+++ b/src/components/so-header.ts
@@ -128,8 +128,11 @@ export class SoHeader extends HTMLElement {
     if (!panel || !btn) return;
 
     const open = panel.getAttribute("data-open") === "true";
-    panel.setAttribute("data-open", open ? "false" : "true");
-    btn.setAttribute("aria-expanded", open ? "false" : "true");
+    const nextOpen = !open;
+    panel.setAttribute("data-open", nextOpen ? "true" : "false");
+    btn.setAttribute("aria-expanded", nextOpen ? "true" : "false");
+    btn.setAttribute("data-open", nextOpen ? "true" : "false");
+    btn.innerHTML = nextOpen ? closeIcon() : burgerIcon();
   }
 
   private render(): void {
@@ -183,6 +186,7 @@ export class SoHeader extends HTMLElement {
     btnMenu.dataset.action = "toggle-menu";
     btnMenu.setAttribute("aria-label", "Menü");
     btnMenu.setAttribute("aria-expanded", "false");
+    btnMenu.setAttribute("data-open", "false");
     btnMenu.innerHTML = burgerIcon();
     actions.append(btnMenu);
 
@@ -356,6 +360,14 @@ export class SoHeader extends HTMLElement {
         display: none;
         color: rgb(204, 0, 0);
       }
+      .menubtn[data-open="true"]{
+        background: rgb(204, 0, 0);
+        border-color: rgb(204, 0, 0);
+        color: #fff;
+      }
+      .menubtn[data-open="true"]:hover{
+        background: rgb(204, 0, 0);
+      }
 
       /* Second row */
       .secondbar{
@@ -453,5 +465,12 @@ function burgerIcon(): string {
   return `
   <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
     <path fill="currentColor" d="M4 7h16v2H4V7zm0 6h16v2H4v-2zm0 6h16v2H4v-2z"/>
+  </svg>`;
+}
+
+function closeIcon(): string {
+  return `
+  <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+    <path fill="currentColor" d="M18.3 5.71 12 12l6.3 6.29-1.41 1.42L10.59 13.4l-6.3 6.31-1.41-1.42L9.17 12 2.88 5.71l1.41-1.42 6.3 6.31 6.3-6.31 1.41 1.42Z"/>
   </svg>`;
 }


### PR DESCRIPTION
### Motivation
- Make the mobile menu toggle reflect open state by showing a white close icon on a red circular background when the panel is opened, and revert to the hamburger when closed.
- Ensure the toggle exposes a state attribute for styling and accessibility (`aria-expanded`).

### Description
- Update `toggleMobileMenu()` to compute the next state, set `data-open` on the button, update `aria-expanded`, and swap the button content between `burgerIcon()` and `closeIcon()`.
- Set the initial button attribute `data-open="false"` and add a new `closeIcon()` helper that renders the close (X) SVG.
- Add CSS rules targeting `.menubtn[data-open="true"]` to apply the red background (`rgb(204,0,0)`), red border, and white icon color while preserving hover behavior.

### Testing
- Ran `npm run build`, which completed successfully.
- Attempted an automated Playwright screenshot to validate the mobile interaction, but the Playwright/Chromium run timed out/crashed in this environment and did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960c8fc1da883288d9ad686ed41185a)