### PR TITLE
Add `so-lead-text` component, global link tokens, demos, docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ abgeleitet aus dem Layout-Prinzip von so.ch.
   - Schrift: `Frutiger, sans-serif`
 - `src/components/so-header.ts` – `<so-header>` Web Component (Shadow DOM)
 - `src/components/so-breadcrumb.ts` – `<so-breadcrumb>` Web Component (Shadow DOM)
+- `src/components/so-lead-text.ts` – `<so-lead-text>` Web Component für Intro-/Lead-Absätze
 - `src/demo/index.html` – Demo-Seite
 - `src/demo/cdn-demo.html` – einfache CDN-Demo-Seite
 - `tests/so-header.test.ts` – Tests (Jest + JSDOM)
 - `tests/so-breadcrumb.test.ts` – Tests (Jest + JSDOM)
+- `tests/so-lead-text.test.ts` – Tests (Jest + JSDOM)
 
 ## Voraussetzungen
 
@@ -75,11 +77,11 @@ git push origin v0.1.1
 Nach dem Publish sind die Web Components z.B. über **unpkg** oder **jsDelivr** verfügbar:
 
 ```html
-<script type="module" src="https://unpkg.com/so-web-components@0.1.1/dist/index.js"></script>
+<script type="module" src="https://unpkg.com/so-web-components@latest/dist/index.js"></script>
 ```
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/so-web-components@0.1.1/dist/index.js"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/so-web-components@latest/dist/index.js"></script>
 ```
 
 Optional ohne Versions-Pin:
@@ -92,7 +94,11 @@ Optional ohne Versions-Pin:
 <script type="module" src="https://cdn.jsdelivr.net/npm/so-web-components/dist/index.js"></script>
 ```
 
-### Einfache Test-Webseite via CDN (Version `0.1.1`)
+Hinweis:
+- `@latest` ist möglich und lädt die aktuellste veröffentlichte Version.
+- Für stabile Produktion empfiehlt sich trotzdem ein expliziter Versions-Pin (z.B. `@0.1.8`).
+
+### Einfache Test-Webseite via CDN (Version `latest`)
 
 Eine fertige Beispielseite liegt unter `src/demo/cdn-demo.html` (wird nach `dist/demo/cdn-demo.html` kopiert):
 
@@ -104,10 +110,10 @@ Eine fertige Beispielseite liegt unter `src/demo/cdn-demo.html` (wird nach `dist
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>so-web-components CDN Demo</title>
 
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/so-web-components@0.1.1/dist/styles/reset.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/so-web-components@0.1.1/dist/styles/fonts.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/so-web-components@0.1.1/dist/styles/tokens.css" />
-  <script type="module" src="https://cdn.jsdelivr.net/npm/so-web-components@0.1.1/dist/index.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/so-web-components@latest/dist/styles/reset.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/so-web-components@latest/dist/styles/fonts.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/so-web-components@latest/dist/styles/tokens.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/so-web-components@latest/dist/index.js"></script>
 </head>
 <body>
   <so-header
@@ -177,6 +183,9 @@ Dann im Browser öffnen:
 
 <so-header></so-header>
 <so-breadcrumb></so-breadcrumb>
+<so-lead-text>
+  <p>Ein kurzer Leadtext mit <a href="#">Link</a>.</p>
+</so-lead-text>
 ```
 
 ### 3) Navigation konfigurieren (optional)
@@ -255,3 +264,32 @@ Einfach per CSS Custom Properties:
 ## Lizenz
 
 MIT (für dieses Beispielprojekt).
+
+
+### `<so-lead-text>`
+
+Für grössere Intro-Absätze unter einer Seitentitel-Zeile.
+
+**Beispiel**
+
+```html
+<h1 class="so-page-title">Kartenkatalog</h1>
+<so-lead-text>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+  <p>Mit <a href="https://www.cogeo.org/">einem Link</a> im Text.</p>
+</so-lead-text>
+```
+
+**Custom Properties**
+
+- `--so-lead-text-margin-top` (Default `24px`)
+- `--so-lead-text-font-size` (Default `1.125rem`)
+- `--so-lead-text-line-height` (Default `1.55`)
+
+### Standard-Linkstyling in `tokens.css`
+
+Ja, das passt gut in `tokens.css` für den globalen Fallback ausserhalb von Shadow-DOM-Komponenten.
+
+- Links sind standardmässig unterstrichen.
+- Hover/Focus rendert rot (`#e01f26`).
+- Übersteuerbar via CSS-Variablen `--so-link-color` und `--so-link-hover-color`.

--- a/src/components/so-lead-text.ts
+++ b/src/components/so-lead-text.ts
@@ -1,0 +1,36 @@
+export class SoLeadText extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+  }
+
+  connectedCallback(): void {
+    this.render();
+  }
+
+  private render(): void {
+    if (!this.shadowRoot) return;
+
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          display: block;
+          margin-top: var(--so-lead-text-margin-top, 24px);
+          color: inherit;
+        }
+
+        ::slotted(p) {
+          margin: 0 0 18px;
+          font-size: var(--so-lead-text-font-size, 1.125rem);
+          line-height: var(--so-lead-text-line-height, 1.55);
+        }
+
+        ::slotted(p:last-child) {
+          margin-bottom: 0;
+        }
+      </style>
+
+      <slot></slot>
+    `;
+  }
+}

--- a/src/demo/cdn-demo.html
+++ b/src/demo/cdn-demo.html
@@ -6,12 +6,12 @@
   <title>so-web-components CDN Demo</title>
 
   <!-- Basis-Styles und Fonts von CDN -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/so-web-components@0.1.1/dist/styles/reset.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/so-web-components@0.1.1/dist/styles/fonts.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/so-web-components@0.1.1/dist/styles/tokens.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/so-web-components@latest/dist/styles/reset.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/so-web-components@latest/dist/styles/fonts.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/so-web-components@latest/dist/styles/tokens.css" />
 
   <!-- Web Components von CDN -->
-  <script type="module" src="https://cdn.jsdelivr.net/npm/so-web-components@0.1.1/dist/index.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/so-web-components@latest/dist/index.js"></script>
 
   <style>
     body {
@@ -22,18 +22,17 @@
     }
 
     main {
-      max-width: 960px;
+      max-width: 1040px;
       margin: 0 auto;
       padding: 24px;
     }
 
-    h1 {
-      margin: 0 0 12px;
-      font-size: 1.5rem;
-    }
-
-    p {
+    .so-page-title {
       margin: 0;
+      font-size: 2.25rem;
+      line-height: 1.15;
+      font-weight: 900;
+      letter-spacing: 0;
     }
   </style>
 </head>
@@ -47,8 +46,11 @@
   </so-breadcrumb>
 
   <main>
-    <h1>Demo-Seite für einfache Webseiten</h1>
-    <p>Diese Seite lädt <code>so-header</code> und <code>so-breadcrumb</code> direkt aus dem CDN.</p>
+    <h1 class="so-page-title">Kartenkatalog</h1>
+    <so-lead-text>
+      <p>Lorem ipsum odor amet, consectetuer adipiscing elit. Nisi donec vulputate posuere auctor dictum ante. Eu convallis mi consequat per sollicitudin vestibulum odio ut maximus. Maecenas tellus sodales eget nunc volutpat nam integer?</p>
+      <p>Ad diam tristique netus conubia dui maecenas pretium aenean. Ridiculus <a href="https://www.cogeo.org/" target="_blank" rel="noopener noreferrer">Cloud Optimized GeoTIFF</a> dictum ligula pretium, ridiculus maecenas tortor.</p>
+    </so-lead-text>
   </main>
 </body>
 </html>

--- a/src/demo/index.html
+++ b/src/demo/index.html
@@ -12,7 +12,15 @@
     body{ background: var(--so-bg); color: var(--so-fg); font-family: var(--so-font-family); }
     main{ padding: 2rem 0; }
     .so-container{ max-width: var(--so-container-size-full); margin-inline:auto; padding-inline: var(--so-container-padding); }
+    .so-page-title {
+      margin: 0;
+      font-size: 2.25rem;
+      line-height: 1.15;
+      font-weight: 900;
+      letter-spacing: 0;
+    }
     .hero{
+      margin-top: 2rem;
       height: 260px;
       border-radius: 12px;
       background: linear-gradient(135deg, rgba(0,0,0,0.08), rgba(0,0,0,0.02));
@@ -38,6 +46,11 @@
 
   <main>
     <div class="so-container">
+      <h1 class="so-page-title">Kartenkatalog</h1>
+      <so-lead-text>
+        <p>Lorem ipsum odor amet, consectetuer adipiscing elit. Nisi donec vulputate posuere auctor dictum ante. Eu convallis mi consequat per sollicitudin vestibulum odio ut maximus. Maecenas tellus sodales eget nunc volutpat nam integer?</p>
+        <p>Ad diam tristique netus conubia dui maecenas pretium aenean. Ridiculus <a href="https://www.cogeo.org/" target="_blank" rel="noopener noreferrer">Cloud Optimized GeoTIFF</a> dictum ligula pretium, ridiculus maecenas tortor.</p>
+      </so-lead-text>
       <div class="hero">Willkommen beim Kanton Solothurn</div>
     </div>
   </main>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { SoBreadcrumb, SoBreadcrumbItem } from "./components/so-breadcrumb.js";
 import { SoHeader } from "./components/so-header.js";
+import { SoLeadText } from "./components/so-lead-text.js";
 
 if (!customElements.get("so-header")) {
   customElements.define("so-header", SoHeader);
@@ -13,4 +14,8 @@ if (!customElements.get("so-breadcrumb-item")) {
   customElements.define("so-breadcrumb-item", SoBreadcrumbItem);
 }
 
-export { SoBreadcrumb, SoBreadcrumbItem, SoHeader };
+if (!customElements.get("so-lead-text")) {
+  customElements.define("so-lead-text", SoLeadText);
+}
+
+export { SoBreadcrumb, SoBreadcrumbItem, SoHeader, SoLeadText };

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -3,6 +3,8 @@
   --so-bg: #fff;
   --so-fg: rgb(47, 72, 88);
   --so-border-color: rgb(223, 223, 223);
+  --so-link-color: inherit;
+  --so-link-hover-color: #e01f26;
 
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale; /* mac Firefox */
@@ -51,4 +53,15 @@
   max-width: var(--so-container-size, var(--so-container-size-medium));
   margin-inline: auto;
   padding-inline: var(--so-container-padding);
+}
+
+
+a{
+  color: var(--so-link-color);
+  text-decoration: underline;
+}
+
+a:hover,
+a:focus-visible{
+  color: var(--so-link-hover-color);
 }

--- a/tests/so-lead-text.test.ts
+++ b/tests/so-lead-text.test.ts
@@ -1,0 +1,39 @@
+describe("so-lead-text", () => {
+  beforeAll(async () => {
+    // @ts-expect-error dist output is generated before tests run.
+    await import("../../dist/index.js");
+  });
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("renders slotted paragraphs", () => {
+    document.body.innerHTML = `
+      <so-lead-text>
+        <p>Erster Absatz.</p>
+        <p>Zweiter Absatz mit <a href="/link">Link</a>.</p>
+      </so-lead-text>
+    `;
+
+    const el = document.querySelector("so-lead-text") as HTMLElement;
+    const shadow = el.shadowRoot;
+
+    expect(shadow).not.toBeNull();
+    expect(el.querySelectorAll("p")).toHaveLength(2);
+    expect(shadow?.querySelector("slot")).not.toBeNull();
+  });
+
+  test("uses expected default lead text styles", () => {
+    const el = document.createElement("so-lead-text");
+    document.body.appendChild(el);
+
+    const shadow = el.shadowRoot!;
+    const style = shadow.querySelector("style")?.textContent ?? "";
+
+    expect(style).toContain("margin-top: var(--so-lead-text-margin-top, 24px)");
+    expect(style).toContain("font-size: var(--so-lead-text-font-size, 1.125rem)");
+    expect(style).toContain("line-height: var(--so-lead-text-line-height, 1.55)");
+    expect(style).toContain("margin: 0 0 18px");
+  });
+});

--- a/tests/tokens.test.ts
+++ b/tests/tokens.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "fs";
+
+describe("tokens.css", () => {
+  test("defines global default link styles", () => {
+    const css = readFileSync("dist/styles/tokens.css", "utf8");
+
+    expect(css).toContain("--so-link-color: inherit");
+    expect(css).toContain("--so-link-hover-color: #e01f26");
+    expect(css).toContain("a{");
+    expect(css).toContain("text-decoration: underline");
+    expect(css).toContain("a:hover");
+    expect(css).toContain("a:focus-visible");
+    expect(css).toContain("color: var(--so-link-hover-color)");
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide a reusable Web Component for prominent intro/lead paragraphs under page titles (`so-lead-text`).
- Standardize global link styling and expose link color tokens so links render consistently outside Shadow DOM.
- Update demo pages and docs to showcase the new component and recommend CDN usage patterns.

### Description

- Added a new Web Component implementation in `src/components/so-lead-text.ts` that renders slotted paragraphs with configurable CSS custom properties (`--so-lead-text-*`).
- Registered and exported `SoLeadText` in `src/index.ts` so the component is available via the bundle and CDN.
- Introduced link tokens and global anchor rules to `src/styles/tokens.css` (`--so-link-color`, `--so-link-hover-color`, and `a`/`a:hover`/`a:focus-visible` styles).
- Updated demo pages (`src/demo/index.html` and `src/demo/cdn-demo.html`) to use the new component, add a `.so-page-title` style, tweak layout widths, and switch CDN examples to `@latest` with guidance in the README.
- Expanded `README.md` to document the new component, its examples and custom properties, and to explain CDN versioning recommendations.
- Added unit tests `tests/so-lead-text.test.ts` for the component and `tests/tokens.test.ts` for the tokens CSS.

### Testing

- Ran the test suite with `npm test` (Jest + JSDOM), including `tests/so-lead-text.test.ts` and `tests/tokens.test.ts`, and the tests passed.
- Verified the demo HTML files render the new component in the local demo environment during development builds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fef15817883289c260c965ae6e77b)